### PR TITLE
docs(git-commits,github-mcp): clarify commit rules and add MCP automation policy

### DIFF
--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,10 +1,3 @@
----
-description: Git commit rules for a well-structured and maintainable codebase.
-globs:
-  - '**/*'
-alwaysApply: true
----
-
 # Git Commit Rules
 
 ## Commit Message Format
@@ -135,6 +128,11 @@ Before committing, ask yourself:
 - [ ] Does this commit do one thing well?
 - [ ] Is the commit message clear and descriptive?
 - [ ] Are all tests passing?
+- [ ] Is the code properly formatted?
+- [ ] Are there any unintended changes included?
+- [ ] Does this commit make sense on its own?
+- [ ] Would this commit be easy to revert if needed?
+
 - [ ] Is the code properly formatted?
 - [ ] Are there any unintended changes included?
 - [ ] Does this commit make sense on its own?

--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,10 +1,3 @@
----
-description: Git commit rules for a project.
-globs:
-  - '**/*'
-alwaysApply: true
----
-
 # Git Commit Rules
 
 ## Commit Message Format
@@ -12,14 +5,12 @@ alwaysApply: true
 Use conventional commit format:
 
 ```bash
-<type>(optional scope): <description>
+<type>[optional scope]: <description>
 
 [optional body]
 
 [optional footer(s)]
 ```
-
-- **Scope**: For extra clarity, especially in larger projects, add a scope in parentheses after the type to indicate the area, file, or feature affected. This is optional but recommended for clarity.
 
 ## Commit Types
 
@@ -36,17 +27,14 @@ Use conventional commit format:
 
 ```bash
 # ✅ Good examples
-feat(auth): add user authentication system
-fix(form): resolve Cypress test port mismatch
-docs(readme): update README with setup instructions
-style: format code with prettier
-refactor(validation): extract form validation logic
-perf(db): optimize database queries
-test(user-card): add unit tests for UserCard component
-chore(deps): update dependencies
-
-# ✅ Also valid (no scope, for general changes)
 feat: add user authentication system
+fix: resolve Cypress test port mismatch
+docs: update README with setup instructions
+style: format code with prettier
+refactor: extract form validation logic
+perf: optimize database queries
+test: add unit tests for UserCard component
+chore: update dependencies
 
 # ❌ Bad examples
 feat: add stuff
@@ -137,6 +125,9 @@ Before committing, ask yourself:
 - [ ] Are all tests passing?
 - [ ] Is the code properly formatted?
 - [ ] Are there any unintended changes included?
+- [ ] Does this commit make sense on its own?
+- [ ] Would this commit be easy to revert if needed?
+
 - [ ] Does this commit make sense on its own?
 - [ ] Would this commit be easy to revert if needed?
 

--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,3 +1,7 @@
+---
+title: Git Commit Rules
+---
+
 # Git Commit Rules
 
 ## Commit Message Format
@@ -128,16 +132,6 @@ Before committing, ask yourself:
 - [ ] Does this commit do one thing well?
 - [ ] Is the commit message clear and descriptive?
 - [ ] Are all tests passing?
-- [ ] Is the code properly formatted?
-- [ ] Are there any unintended changes included?
-- [ ] Does this commit make sense on its own?
-- [ ] Would this commit be easy to revert if needed?
-
-- [ ] Is the code properly formatted?
-- [ ] Are there any unintended changes included?
-- [ ] Does this commit make sense on its own?
-- [ ] Would this commit be easy to revert if needed?
-
 - [ ] Is the code properly formatted?
 - [ ] Are there any unintended changes included?
 - [ ] Does this commit make sense on its own?

--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,8 +1,5 @@
 ---
-description: Git commit rules for a project.
-globs:
-  - '**/*'
-alwaysApply: true
+title: Git Commit Rules
 ---
 
 # Git Commit Rules
@@ -137,6 +134,12 @@ Before committing, ask yourself:
 - [ ] Are all tests passing?
 - [ ] Is the code properly formatted?
 - [ ] Are there any unintended changes included?
+- [ ] Does this commit make sense on its own?
+- [ ] Would this commit be easy to revert if needed?
+
+- [ ] Does this commit make sense on its own?
+- [ ] Would this commit be easy to revert if needed?
+
 - [ ] Does this commit make sense on its own?
 - [ ] Would this commit be easy to revert if needed?
 

--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,5 +1,8 @@
 ---
-title: Git Commit Rules
+description: Git commit rules for a project.
+globs:
+  - '**/*'
+alwaysApply: true
 ---
 
 # Git Commit Rules
@@ -134,5 +137,8 @@ Before committing, ask yourself:
 - [ ] Are all tests passing?
 - [ ] Is the code properly formatted?
 - [ ] Are there any unintended changes included?
+- [ ] Does this commit make sense on its own?
+- [ ] Would this commit be easy to revert if needed?
+
 - [ ] Does this commit make sense on its own?
 - [ ] Would this commit be easy to revert if needed?

--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,3 +1,10 @@
+---
+description: Git commit rules for a project.
+globs:
+  - '**/*'
+alwaysApply: true
+---
+
 # Git Commit Rules
 
 ## Commit Message Format
@@ -5,12 +12,14 @@
 Use conventional commit format:
 
 ```bash
-<type>[optional scope]: <description>
+<type>(optional scope): <description>
 
 [optional body]
 
 [optional footer(s)]
 ```
+
+- **Scope**: For extra clarity, especially in larger projects, add a scope in parentheses after the type to indicate the area, file, or feature affected. This is optional but recommended for clarity.
 
 ## Commit Types
 
@@ -27,14 +36,17 @@ Use conventional commit format:
 
 ```bash
 # ✅ Good examples
-feat: add user authentication system
-fix: resolve Cypress test port mismatch
-docs: update README with setup instructions
+feat(auth): add user authentication system
+fix(form): resolve Cypress test port mismatch
+docs(readme): update README with setup instructions
 style: format code with prettier
-refactor: extract form validation logic
-perf: optimize database queries
-test: add unit tests for UserCard component
-chore: update dependencies
+refactor(validation): extract form validation logic
+perf(db): optimize database queries
+test(user-card): add unit tests for UserCard component
+chore(deps): update dependencies
+
+# ✅ Also valid (no scope, for general changes)
+feat: add user authentication system
 
 # ❌ Bad examples
 feat: add stuff
@@ -125,9 +137,6 @@ Before committing, ask yourself:
 - [ ] Are all tests passing?
 - [ ] Is the code properly formatted?
 - [ ] Are there any unintended changes included?
-- [ ] Does this commit make sense on its own?
-- [ ] Would this commit be easy to revert if needed?
-
 - [ ] Does this commit make sense on its own?
 - [ ] Would this commit be easy to revert if needed?
 

--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,3 +1,10 @@
+---
+description: Git commit rules for a well-structured and maintainable codebase.
+globs:
+  - '**/*'
+alwaysApply: true
+---
+
 # Git Commit Rules
 
 ## Commit Message Format

--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,26 +1,23 @@
----
-description: Git commit message conventions and best practices for consistent commit history
-globs: ["**/*"]
-alwaysApply: true
----
-
 # Git Commit Rules
 
 ## Commit Message Format
 
 Use conventional commit format:
+
 ```bash
-<type>[optional scope]: <description>
+<type>(optional scope): <description>
 
 [optional body]
 
 [optional footer(s)]
 ```
 
+- **Scope**: For extra clarity, especially in larger projects, add a scope in parentheses after the type to indicate the area, file, or feature affected. This is optional but recommended for clarity.
+
 ## Commit Types
 
 - `feat`: A new feature
-- `fix`: A bug fix  
+- `fix`: A bug fix
 - `docs`: Documentation only changes
 - `style`: Changes that do not affect the meaning of the code
 - `refactor`: A code change that neither fixes a bug nor adds a feature
@@ -32,14 +29,17 @@ Use conventional commit format:
 
 ```bash
 # ✅ Good examples
-feat: add user authentication system
-fix: resolve Cypress test port mismatch
-docs: update README with setup instructions
+feat(auth): add user authentication system
+fix(form): resolve Cypress test port mismatch
+docs(readme): update README with setup instructions
 style: format code with prettier
-refactor: extract form validation logic
-perf: optimize database queries
-test: add unit tests for UserCard component
-chore: update dependencies
+refactor(validation): extract form validation logic
+perf(db): optimize database queries
+test(user-card): add unit tests for UserCard component
+chore(deps): update dependencies
+
+# ✅ Also valid (no scope, for general changes)
+feat: add user authentication system
 
 # ❌ Bad examples
 feat: add stuff
@@ -96,6 +96,7 @@ fix: resolved navigation bug
 ## Common Patterns
 
 ### Feature Development
+
 ```bash
 feat: add user registration form component
 feat: add form validation with Zod schema
@@ -105,6 +106,7 @@ docs: add registration form documentation
 ```
 
 ### Bug Fixes
+
 ```bash
 fix: resolve Cypress test port mismatch
 fix: prevent form submission with empty fields
@@ -112,6 +114,7 @@ fix: handle API error responses properly
 ```
 
 ### Refactoring
+
 ```bash
 refactor: extract form validation logic to custom hook
 refactor: simplify component prop interface
@@ -121,9 +124,15 @@ refactor: consolidate duplicate API calls
 ## Review Checklist
 
 Before committing, ask yourself:
+
 - [ ] Does this commit do one thing well?
 - [ ] Is the commit message clear and descriptive?
 - [ ] Are all tests passing?
+- [ ] Is the code properly formatted?
+- [ ] Are there any unintended changes included?
+- [ ] Does this commit make sense on its own?
+- [ ] Would this commit be easy to revert if needed?
+
 - [ ] Is the code properly formatted?
 - [ ] Are there any unintended changes included?
 - [ ] Does this commit make sense on its own?

--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,5 +1,7 @@
 ---
-title: Git Commit Rules
+description: Git commit message conventions and best practices for consistent commit history
+globs: ['**/*']
+alwaysApply: true
 ---
 
 # Git Commit Rules
@@ -134,6 +136,9 @@ Before committing, ask yourself:
 - [ ] Are all tests passing?
 - [ ] Is the code properly formatted?
 - [ ] Are there any unintended changes included?
+- [ ] Does this commit make sense on its own?
+- [ ] Would this commit be easy to revert if needed?
+
 - [ ] Does this commit make sense on its own?
 - [ ] Would this commit be easy to revert if needed?
 

--- a/.cursor/rules/github-mcp.mdc
+++ b/.cursor/rules/github-mcp.mdc
@@ -1,0 +1,48 @@
+# GitHub MCP Integration Rules
+
+description: Rules and best practices for handling GitHub MCP (Multi-Channel Platform) automation in this repository.
+globs: ["**/*"]
+alwaysApply: true
+
+## PR Management
+
+- All MCP-created PRs must include `[Bot]` in the description.
+- PR titles should clearly indicate MCP origin, e.g., `fix(example): [Bot] update config for MCP`.
+- MCP must not merge PRs; only open, update, or close as instructed by a maintainer.
+- MCP should update PR descriptions to reflect the latest changes and diff summary.
+
+## Issue Management
+
+- MCP may open issues for automation errors or workflow failures, but must assign to `@maintainers`.
+- Issues created by MCP should include `[Bot]` in the title or body for transparency.
+- MCP should not close issues unless explicitly instructed.
+
+## Bot Etiquette
+
+- All comments by MCP must start with `[Bot]` for transparency.
+- MCP should respond inline to specific PR comments when addressing feedback.
+- MCP should never delete user comments or override human feedback.
+
+## Error Handling
+
+- On error, MCP should notify maintainers via issue or PR comment, including error details and steps taken.
+- MCP should not attempt destructive actions (e.g., force-push, branch deletion) on error.
+
+## Security & Permissions
+
+- MCP must never force-push or delete branches.
+- MCP should only operate within its assigned permissions and never escalate privileges.
+
+## Change Management
+
+- Changes to this rules file must be made via PR and require review by a maintainer.
+- All updates to MCP automation logic should be documented in this file or linked documentation.
+
+---
+
+_This file governs all MCP automation and bot activity for this repository. For questions or updates, contact the maintainers._
+description:
+globs:
+alwaysApply: false
+
+---

--- a/src/components/ExampleForm.tsx
+++ b/src/components/ExampleForm.tsx
@@ -1,3 +1,4 @@
+// MCP PR test: this is a test comment to verify PR creation
 'use client';
 
 import { useForm } from 'react-hook-form';

--- a/src/components/ExampleForm.tsx
+++ b/src/components/ExampleForm.tsx
@@ -28,7 +28,6 @@ const formSchema = z
 type FormData = z.infer<typeof formSchema>;
 
 export function ExampleForm() {
-  // Form configuration with React Hook Form and Zod validation
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {

--- a/src/components/ExampleForm.tsx
+++ b/src/components/ExampleForm.tsx
@@ -1,4 +1,3 @@
-// MCP PR test: this is a test comment to verify PR creation
 'use client';
 
 import { useForm } from 'react-hook-form';

--- a/src/components/ExampleForm.tsx
+++ b/src/components/ExampleForm.tsx
@@ -28,6 +28,7 @@ const formSchema = z
 type FormData = z.infer<typeof formSchema>;
 
 export function ExampleForm() {
+  // Form configuration with React Hook Form and Zod validation
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {


### PR DESCRIPTION
This PR updates repository documentation and standards:

- Clarifies and improves `.cursor/rules/git-commits.mdc` (commit message rules)
  - Restores YAML frontmatter (no --- lines)
  - Recommends using a scope in commit messages
  - Improves examples and formatting
- Adds `.cursor/rules/github-mcp.mdc` to govern GitHub MCP (Multi-Channel Platform) automation and bot activity
  - Covers PR/issue management, bot etiquette, error handling, security, and change management

No functional code changes—this is a documentation and standards update only.

Please review the new MCP automation policy and improved commit message rules.