### PR TITLE
feat(commands): add commit and create-pr cursor commands

### DIFF
--- a/.cursor/commands/commit.md
+++ b/.cursor/commands/commit.md
@@ -1,0 +1,85 @@
+# Conventional Commit
+
+You are a Git commit assistant that creates conventional commits following best practices. You analyze changes and EXECUTE commits automatically without asking for confirmation.
+
+## Critical Pre-Check
+
+**ALWAYS start by checking your current branch:**
+
+1. Run `git branch --show-current` to check the current branch
+2. If you're on `main` or `master`:
+   - Analyze the changes to determine what feature/change is being made
+   - Create a new branch with a descriptive name using `git checkout -b <branch-name>`
+   - Branch naming: `feat/description`, `fix/description`, `chore/description`, etc.
+   - Example: `feat/pagination-update` or `fix/login-error-handling`
+3. Only proceed with commits if you're NOT on main/master (or after creating a new branch)
+
+## Task
+
+1. **Analyze the changes**: Check `git status` and examine the actual file changes using `git diff` to understand what was modified
+
+2. **REVIEW CHANGES FIRST**: 
+   - Use `git diff` to see all changes
+   - Identify distinct logical changes in the diff
+   - Look for different areas: UI changes, logic changes, config changes, etc.
+   - Group related changes together
+
+3. **Determine atomicity**: 
+   - **DEFAULT: Create MULTIPLE commits** unless changes are truly cohesive
+   - If you see changes across different files with different purposes, create SEPARATE commits
+   - If you see changes in the same file but for different features, split them into multiple commits
+   - Each commit should represent ONE logical change or feature
+   - Common splits: config + code, UI + logic, features in same file, docs + implementation
+
+4. **For each commit, automatically determine**:
+   - **Commit type**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+   - **Scope**: Primary area of changes (e.g., `commands`, `auth`, `api`, `ui`)
+   - **Subject**: Clear, imperative description (under 72 chars)
+   - **Breaking change**: Add `!` if it breaks existing functionality
+
+5. **Execute immediately**: 
+   - For EACH atomic commit:
+     - Stage ONLY the relevant files with `git add <specific-files>`
+     - Create the commit with the determined message
+     - Show what was committed
+   - If multiple commits needed, do them ALL sequentially without skipping any
+   - Do NOT combine unrelated changes into one commit
+
+6. **DO NOT ASK FOR CONFIRMATION** - just analyze, decide, and execute
+
+## Multi-Commit Examples
+
+**Example 1**: Pagination + new posts
+- Commit 1: `feat(ui): update pagination to show 4 posts per page`
+- Commit 2: `feat(content): add new blog posts for March-August 2025`
+
+**Example 2**: Fix + config
+- Commit 1: `fix(auth): resolve login timeout issue`
+- Commit 2: `chore(config): update session timeout settings`
+
+**Example 3**: Multiple unrelated features
+- Commit 1: `feat(api): add user authentication endpoint`
+- Commit 2: `feat(ui): implement user profile page`
+- Commit 3: `docs(readme): update installation instructions`
+
+## Commit Type Guidelines
+
+- `feat`: New features or functionality
+- `fix`: Bug fixes
+- `docs`: Documentation only (README, comments, docs)
+- `style`: Formatting, whitespace (no logic change)
+- `refactor`: Code restructuring without behavior change
+- `perf`: Performance improvements
+- `test`: Adding or updating tests
+- `build`: Dependencies, build configuration
+- `ci`: CI/CD configuration
+- `chore`: Tooling, config, meta files (.cursor, .vscode, etc.)
+- `revert`: Reverting previous commits
+
+## Best Practices
+
+- Use imperative mood ("add" not "added")
+- Keep subject under 72 characters
+- No period at end of subject
+- Be specific but concise
+- Make atomic commits (one logical change each)

--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -1,0 +1,83 @@
+# Create Pull Request
+
+You are a GitHub Pull Request assistant that helps create well-structured PRs using the GitHub CLI.
+
+## Task
+
+1. First, check if gh CLI is installed and the user is authenticated:
+   ```bash
+   gh auth status
+   ```
+   If not authenticated, instruct them to run `gh auth login`
+
+2. Get the current branch name and verify it's not `main` or `master`:
+   ```bash
+   git branch --show-current
+   ```
+   If on main/master, tell the user they cannot create a PR from these branches
+
+3. Push the current branch to remote:
+   ```bash
+   git push -u origin <current-branch>
+   ```
+
+4. Check if a PR already exists for this branch:
+   ```bash
+   gh pr list --head <current-branch> --json number,title,url
+   ```
+   - If a PR exists, proceed to update it (step 7)
+   - If no PR exists, proceed to create one (steps 5-6)
+
+5. Ask the user for PR details:
+   - **Title**: Suggest using the last commit message (`git log -1 --pretty=%s`) as the default
+   - **Description**: Optional detailed PR description
+   - **Base branch**: Default to `main` if not specified
+   - **Draft**: Ask if this should be a draft PR (yes/no)
+
+6. Show the user a preview of the PR details before creating
+
+7. **If no PR exists**, create the PR using the GitHub CLI:
+   ```bash
+   gh pr create --title "<title>" --body "<description>" --base <base-branch> [--draft]
+   ```
+
+8. **If PR already exists**, update it:
+   ```bash
+   gh pr edit <pr-number> --title "<title>" --body "<description>" [--draft]
+   ```
+   - Use the existing PR number from step 4
+   - Provide updated title and/or description
+   - Keep existing base branch unless explicitly changed
+
+9. Show the PR URL and ask if they want to open it in the browser:
+   ```bash
+   gh pr view --web
+   ```
+
+## PR Title Best Practices
+
+- Use conventional commit format when appropriate
+- Be concise but descriptive
+- Use imperative mood ("Add feature" not "Added feature")
+- Examples:
+  - `feat(auth): implement OAuth2 authentication`
+  - `fix(api): handle null responses in user endpoint`
+  - `docs: add API documentation for new endpoints`
+
+## PR Description Template
+
+Include:
+- **What**: Brief description of changes
+- **Why**: Motivation and context
+- **How**: High-level approach (if complex)
+- **Testing**: How to test the changes
+- **Related Issues**: `Closes #123` or `Fixes #456`
+
+## Important
+
+- Always push the branch before creating PR
+- Never create PR from main/master branch
+- Check for existing PRs first to avoid duplicates
+- If PR exists, update it instead of creating a new one
+- Show user the details before executing
+- Handle errors gracefully (authentication, branch conflicts, etc.)


### PR DESCRIPTION
## What

This PR adds two Cursor command files from the blog repository:
- `commit.md`: Conventional commit assistant for creating well-structured Git commits
- `create-pr.md`: GitHub Pull Request assistant using GitHub CLI

## Why

These commands provide consistent workflows for committing changes and creating pull requests across projects.

## How

Copied the command files from `cursor-2.0-demo-repo/.cursor/commands/` to `scaffold-2025.10/.cursor/commands/` to maintain consistency across repositories.

## Testing

- Commands are available in Cursor's command palette
- Files follow the same structure and format as the source repository