### PR TITLE
feat: add /help command to list available commands

### DIFF
--- a/.cursor/commands/help.md
+++ b/.cursor/commands/help.md
@@ -1,0 +1,58 @@
+# Help - Available Commands
+
+Show the user all available Cursor commands and guide them on what to do.
+
+## Instructions for AI
+
+Display this information in a friendly, clear way:
+
+---
+
+## 👋 Welcome! Here are the commands you can use:
+
+### 🚀 `/setup`
+**Run this first!** Installs everything your project needs to work.
+- Installs the package manager (pnpm) if needed
+- Downloads all project dependencies
+- Creates configuration files
+- Takes about 1-2 minutes
+
+### ▶️ `/start`
+**Launches your app** so you can see it in the browser.
+- Starts the development server
+- Open http://localhost:3000 to see your app
+- Changes you make will auto-refresh!
+
+### 🆕 `/new-project`
+**Creates a fresh copy** of this template for a new project.
+- Asks you for a project name
+- Copies everything to a new folder
+- Guides you to open it in Cursor
+
+### ❓ `/help`
+**You're here!** Shows this list of commands.
+
+---
+
+## 💡 Suggested Workflow
+
+**First time?** Do this:
+1. Type `/setup` and wait for it to finish
+2. Type `/start` to launch your app
+3. Open http://localhost:3000 in your browser
+
+**Starting a new project?**
+1. Type `/new-project`
+2. Follow the instructions to open it in Cursor
+3. Run `/setup` in the new project
+
+**Need help anytime?**
+- Type `/help` to see this guide
+- Or just ask me anything in the chat!
+
+---
+
+## Tone
+
+Be warm and welcoming. This is likely a non-technical user who needs clear guidance. Make them feel supported and confident they can do this!
+


### PR DESCRIPTION
## Overview

Adds a `/help` command that gives non-technical users a friendly overview of all available Cursor commands.

## What it shows

- **All available commands**: `/setup`, `/start`, `/new-project`, `/help`
- **What each command does**: Clear, simple explanations
- **Suggested workflows**: Step-by-step guidance for first-time users and new projects

## Why

Instead of relying on users to read the README or figure things out, they can just type `/help` anytime to see what's available and how to use it.

## Example output

When a user types `/help`, they'll see:
- Welcome message with all commands listed
- Emoji icons for easy scanning
- Suggested workflow for first-time setup
- Encouragement to ask questions in chat