### PR TITLE
feat: add number/date formatting conventions and utilities

### DIFF
--- a/.cursor/rules/number-formatting.mdc
+++ b/.cursor/rules/number-formatting.mdc
@@ -1,0 +1,62 @@
+---
+description: Enforce consistent number, currency, and percentage formatting
+alwaysApply: true
+---
+
+# Number, Currency & Percentage Formatting
+
+Use the utility functions in `src/lib/formatters.ts` for all numeric display. Never inline formatting logic or use raw `toFixed`, `toLocaleString`, or `Intl.NumberFormat` directly in components.
+
+## Functions
+
+| Function             | Purpose                        | Example Output          |
+|----------------------|--------------------------------|-------------------------|
+| `formatNumber`       | Compact display (axes, labels) | `1.5k`, `10k`, `2.3M`  |
+| `formatNumberExact`  | Full precision with separators | `1,234,567`             |
+| `formatCurrency`     | Compact USD with `$` prefix    | `$1.5k`, `$10k`, `$2M` |
+| `formatCurrencyExact`| Full precision USD             | `$1,234,567.89`         |
+| `formatPercent`      | Smart decimal percentage       | `12.5%`, `50%`          |
+
+## When to Use Which
+
+- **Chart axes, bar labels, summary cards** → compact (`formatNumber`, `formatCurrency`)
+- **Tooltips, tables, detail views** → exact (`formatNumberExact`, `formatCurrencyExact`)
+- **Ratios, growth rates, utilization** → `formatPercent`
+
+## Forbidden
+
+- `value.toFixed(2)` in JSX — use a formatter function
+- `value.toLocaleString()` directly in components — use `formatNumberExact`
+- `Intl.NumberFormat` directly — the formatters handle this internally
+- Template literals like `` `$${value}` `` — use `formatCurrency` or `formatCurrencyExact`
+- `Math.round(value / 1000) + 'k'` inline — use `formatNumber`
+
+## Compact Format Tiers
+
+Numbers and currency follow the same tier logic:
+
+| Range           | Format          | Example          |
+|-----------------|-----------------|------------------|
+| < 1,000         | as-is (rounded) | `847`            |
+| 1,000–9,999     | 1 decimal + k   | `1.5k`, `9.9k`  |
+| 10,000–999,999  | whole k         | `10k`, `450k`    |
+| 1M–999M         | 1 decimal + M   | `1.2M`, `450M`   |
+| 1B+             | 1 decimal + B   | `1.5B`           |
+
+Trailing `.0` is always stripped (e.g., `2.0M` → `2M`).
+
+## Examples
+
+```typescript
+import { formatNumber, formatCurrency, formatPercent } from '@/lib/formatters';
+
+// ❌ BAD
+<span>{value.toLocaleString()}</span>
+<span>${(value / 1000).toFixed(1)}k</span>
+<span>{(ratio * 100).toFixed(1)}%</span>
+
+// ✅ GOOD
+<span>{formatNumber(value)}</span>
+<span>{formatCurrency(value)}</span>
+<span>{formatPercent(ratio)}</span>
+```

--- a/.cursor/rules/use-date-fns.mdc
+++ b/.cursor/rules/use-date-fns.mdc
@@ -1,19 +1,21 @@
 ---
-description: Enforce date-fns for all date/time operations
+description: Enforce date-fns for all date/time operations with standard format patterns
 alwaysApply: true
 ---
 
-# Use date-fns for All Date Operations
+# Date Handling & Formatting
 
-Use `date-fns` for formatting, parsing, comparing, and manipulating dates. Do not use native `Date` methods for these operations.
+Use `date-fns` for all date operations. Use the utility functions in `src/lib/date.ts` for formatting — never format dates inline in components.
 
-## Allowed
+## Library Rule: Always Use date-fns
+
+### Allowed
 
 - `new Date()` to capture the current moment (and nothing else)
 - `Date.now()` for timestamps
 - Passing `Date` objects into `date-fns` functions
 
-## Forbidden
+### Forbidden
 
 - `Date.parse()`, `new Date(stringValue)` for parsing — use `parse` or `parseISO` from date-fns
 - `.toLocaleDateString()`, `.toISOString()`, `.toDateString()` for display — use `format` from date-fns
@@ -21,25 +23,7 @@ Use `date-fns` for formatting, parsing, comparing, and manipulating dates. Do no
 - Manual date arithmetic (`date.getTime() + 86400000`) — use `addDays`, `addHours`, `subWeeks`, etc.
 - `Intl.DateTimeFormat` for formatting — use `format` or `formatDistance` from date-fns
 
-## Examples
-
-```typescript
-import { format, parseISO, addDays, differenceInDays, isAfter } from 'date-fns';
-
-// ❌ BAD
-const formatted = new Date().toLocaleDateString('en-US');
-const parsed = new Date('2025-03-15');
-const tomorrow = new Date(Date.now() + 86400000);
-const year = someDate.getFullYear();
-
-// ✅ GOOD
-const formatted = format(new Date(), 'MM/dd/yyyy');
-const parsed = parseISO('2025-03-15');
-const tomorrow = addDays(new Date(), 1);
-const year = getYear(someDate);
-```
-
-## Imports
+### Imports
 
 Always import individual functions — never import the entire library:
 
@@ -49,4 +33,49 @@ import * as dateFns from 'date-fns';
 
 // ✅ GOOD
 import { format, addDays } from 'date-fns';
+```
+
+## Format Patterns
+
+Use the utility functions in `src/lib/date.ts` instead of calling `format()` directly in components. These enforce consistent patterns across the app:
+
+| Function          | Pattern                        | Example Output                   |
+|-------------------|--------------------------------|----------------------------------|
+| `formatDate`      | `MMM d, yyyy`                  | `Jan 5, 2026`                    |
+| `formatDateTime`  | `MMM d, yyyy 'at' h:mm a`     | `Jan 5, 2026 at 3:45 PM`        |
+| `formatDateRange` | smart (avoids redundancy)      | `Jan 1 – 31, 2026`              |
+| `timeAgo`         | relative                       | `3 hours ago`                    |
+
+### Date Range Formatting
+
+`formatDateRange` collapses redundant parts automatically:
+
+- Same month: `Jan 1 – 31, 2026`
+- Same year: `Jan 1 – Feb 14, 2026`
+- Different years: `Dec 15, 2025 – Jan 10, 2026`
+
+### ISO Transport Format
+
+When sending dates over the wire (API requests, query params), use `yyyy-MM-dd`:
+
+```typescript
+import { format } from 'date-fns';
+
+const isoDate = format(someDate, 'yyyy-MM-dd');
+```
+
+## Examples
+
+```typescript
+import { formatDate, formatDateTime, formatDateRange, timeAgo } from '@/lib/date';
+
+// ❌ BAD — inline formatting in components
+<span>{new Date(dateStr).toLocaleDateString('en-US')}</span>
+<span>{format(parseISO(dateStr), 'MMM d, yyyy')}</span>
+
+// ✅ GOOD — use the utility functions
+<span>{formatDate(dateStr)}</span>
+<span>{formatDateTime(dateStr)}</span>
+<span>{formatDateRange(startIso, endIso)}</span>
+<span>{timeAgo(dateStr)}</span>
 ```

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -9,6 +9,8 @@ import {
   differenceInDays,
   addDays,
   subDays,
+  getYear,
+  getMonth,
 } from 'date-fns';
 
 /**
@@ -35,6 +37,25 @@ export function formatDateTime(date: Date | string): string {
 export function timeAgo(date: Date | string): string {
   const parsed = typeof date === 'string' ? parseISO(date) : date;
   return formatDistanceToNow(parsed, { addSuffix: true });
+}
+
+/**
+ * Smart date range formatting that avoids redundancy.
+ * Same month: "Jan 1 – 31, 2026". Same year: "Jan 1 – Feb 14, 2026".
+ */
+export function formatDateRange(startIso: string, endIso: string): string {
+  const start = parseISO(startIso);
+  const end = parseISO(endIso);
+  const sameYear = getYear(start) === getYear(end);
+  const sameMonth = sameYear && getMonth(start) === getMonth(end);
+
+  if (sameMonth) {
+    return `${format(start, 'MMM d')} – ${format(end, 'd, yyyy')}`;
+  }
+  if (sameYear) {
+    return `${format(start, 'MMM d')} – ${format(end, 'MMM d, yyyy')}`;
+  }
+  return `${format(start, 'MMM d, yyyy')} – ${format(end, 'MMM d, yyyy')}`;
 }
 
 // Re-export commonly used date-fns functions for convenience

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,0 +1,75 @@
+/**
+ * Compact number formatting with context-aware precision.
+ * Under 1k: as-is. 1k–9.9k: 1 decimal k. 10k+: whole k. 1M+: 1 decimal M. 1B+: 1 decimal B.
+ */
+export function formatNumber(value: number): string {
+  if (value >= 1_000_000_000) {
+    const formatted = (value / 1_000_000_000).toFixed(1);
+    return `${formatted.replace(/\.0$/, '')}B`;
+  }
+  if (value >= 1_000_000) {
+    const formatted = (value / 1_000_000).toFixed(1);
+    return `${formatted.replace(/\.0$/, '')}M`;
+  }
+  if (value >= 10_000) {
+    return `${Math.round(value / 1_000)}k`;
+  }
+  if (value >= 1_000) {
+    const formatted = (value / 1_000).toFixed(1);
+    return `${formatted.replace(/\.0$/, '')}k`;
+  }
+  return Math.round(value).toLocaleString('en-US');
+}
+
+/**
+ * Full-precision number with locale separators. No decimals.
+ */
+export function formatNumberExact(value: number): string {
+  return value.toLocaleString('en-US', { maximumFractionDigits: 0 });
+}
+
+/**
+ * Compact currency with $ prefix.
+ * Under $1k: full. $1k–$9.9k: 1 decimal k. $10k+: whole k. $1M+: 1 decimal M. $1B+: 1 decimal B.
+ */
+export function formatCurrency(value: number): string {
+  if (value >= 1_000_000_000) {
+    const formatted = (value / 1_000_000_000).toFixed(1);
+    return `$${formatted.replace(/\.0$/, '')}B`;
+  }
+  if (value >= 1_000_000) {
+    const formatted = (value / 1_000_000).toFixed(1);
+    return `$${formatted.replace(/\.0$/, '')}M`;
+  }
+  if (value >= 10_000) {
+    return `$${Math.round(value / 1_000)}k`;
+  }
+  if (value >= 1_000) {
+    const formatted = (value / 1_000).toFixed(1);
+    return `$${formatted.replace(/\.0$/, '')}k`;
+  }
+  return `$${Math.round(value).toLocaleString('en-US')}`;
+}
+
+/**
+ * Full-precision currency with locale separators.
+ * E.g., 1234567.89 → "$1,234,567.89"
+ */
+export function formatCurrencyExact(value: number, decimals: number = 2): string {
+  return value.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+/**
+ * Format a ratio as a percentage. Pass alreadyPercent=true if the value is already 0–100.
+ * 0.125 → "12.5%", 0.50 → "50%"
+ */
+export function formatPercent(value: number, alreadyPercent: boolean = false): string {
+  const percentValue = alreadyPercent ? value : value * 100;
+  const formatted = percentValue % 1 === 0 ? percentValue.toFixed(0) : percentValue.toFixed(1);
+  return `${formatted}%`;
+}


### PR DESCRIPTION
## Summary

- **New rule: `number-formatting.mdc`** — enforces consistent number, currency, and percent formatting via `src/lib/formatters.ts` utilities. Covers compact tiers (1k, 1.5M, $10k), exact formatting, and explicitly forbids inline formatting in components.
- **Updated rule: `use-date-fns.mdc`** — expanded from "use this library" to "use these specific format patterns." Now documents standard patterns (MMM d, yyyy), smart date range formatting, ISO transport format, and directs to `src/lib/date.ts` utilities.
- **New utility: `src/lib/formatters.ts`** — `formatNumber`, `formatNumberExact`, `formatCurrency`, `formatCurrencyExact`, `formatPercent`. Ported from anyusage-rebuild.
- **Updated utility: `src/lib/date.ts`** — added `formatDateRange` with smart redundancy collapsing (same month/year detection). Uses `getYear`/`getMonth` from date-fns instead of native Date methods.

## Why

The anyusage-rebuild established formatting conventions that new projects should follow. Without these rules and utilities in the scaffold, each new app would reinvent formatting with inconsistent patterns.

## Test plan

- [ ] `pnpm run lint` passes (verified)
- [ ] Review `formatters.ts` functions match anyusage-rebuild behavior
- [ ] Review `formatDateRange` output for same-month, same-year, and cross-year cases
- [ ] Confirm rules are `alwaysApply: true` and will load in new projects

Made with [Cursor](https://cursor.com)