### PR TITLE
feat(commands): request bugbot review in create-pr

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -49,7 +49,14 @@ You are a GitHub Pull Request assistant that helps create well-structured PRs us
    - Provide updated title and/or description
    - Keep existing base branch unless explicitly changed
 
-9. Show the PR URL and ask if they want to open it in the browser:
+9. After creating or updating the PR, post a review request comment:
+   ```bash
+   gh pr comment <pr-number> --body "@bugbot review"
+   ```
+   - If you just created the PR and do not yet have the number, fetch it first with `gh pr view --json number,url`
+   - If the PR already existed, use the number from step 4
+
+10. Show the PR URL and ask if they want to open it in the browser:
    ```bash
    gh pr view --web
    ```
@@ -79,5 +86,6 @@ Include:
 - Never create PR from main/master branch
 - Check for existing PRs first to avoid duplicates
 - If PR exists, update it instead of creating a new one
+- Always comment `@bugbot review` after creating or updating the PR
 - Show user the details before executing
 - Handle errors gracefully (authentication, branch conflicts, etc.)


### PR DESCRIPTION
## Summary
- update the scaffold's `/create-pr` command so it posts `@bugbot review` after creating or updating a pull request
- document how the command should fetch the PR number when needed before posting the comment
- make the bugbot review request part of the command's required workflow for all new projects created from this scaffold

## Test plan
- [x] review `.cursor/commands/create-pr.md`
- [x] verify the command now includes `gh pr comment <pr-number> --body "@bugbot review"`
- [x] confirm the workflow works for both newly created and existing PRs

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/workflow update only; it changes the PR creation instructions to always post a review-request comment and may affect contributor workflow if the bot or permissions are misconfigured.
> 
> **Overview**
> Updates the `.cursor/commands/create-pr.md` workflow to **always post an `@bugbot review` comment** after creating or editing a PR.
> 
> Adds guidance for obtaining the PR number via `gh pr view --json number,url` when it isn’t already known, and makes this review-request step an explicit requirement in the command’s “Important” checklist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 925fb87c91aa62bd1bbdca7c84fb64cae4322cb2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->