### PR TITLE
chore(commands): strip scaffold-only files from new projects

### DIFF
--- a/.cursor/commands/new-project.md
+++ b/.cursor/commands/new-project.md
@@ -50,8 +50,11 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
 5. **Clean up the new project**:
    ```bash
    cd "<destination>/<project-name>"
-   rm -rf node_modules .git pnpm-lock.yaml package-lock.json
+   rm -f .cursor/commands/new-project.md
+   rm -f .cursor/commands/update.md
    rm -f .cursor/commands/bump-scaffold.md
+   rm -f .cursor/rules/scaffold-protection.mdc
+   rm -rf node_modules .git pnpm-lock.yaml package-lock.json
    rm -f scripts/bump-scaffold.sh
    rmdir scripts 2>/dev/null || true
    ```
@@ -59,8 +62,9 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
 6. **Update copied scaffold metadata**:
    - Change the `"name"` field in `package.json` to the new project name
    - Remove the `"bump:scaffold"` script from `package.json`
-   - Update `.cursor/commands/help.md` to remove any `/bump-scaffold` section or scaffold-maintainer workflow text
-   - Make sure the new project does not advertise scaffold-only maintenance commands
+   - Update `.cursor/commands/help.md` to remove `/new-project`, `/update`, and `/bump-scaffold` sections plus any scaffold-maintainer workflow text
+   - If the copied project keeps the starter `README.md`, remove scaffold-only command references there as well
+   - Make sure the new project does not advertise scaffold-only maintenance commands or include scaffold-protection prompts
 
 7. **Initialize fresh git repo**:
    ```bash


### PR DESCRIPTION
## Summary
- remove scaffold-only command files and the scaffold-protection rule from projects created via `/new-project`
- tell the copied project to scrub `/new-project`, `/update`, and `/bump-scaffold` from its help text
- note that copied starter READMEs should also stop advertising scaffold-only workflows

## Test plan
- [ ] Not run (command-doc change only)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts the `/new-project` checklist for deleting scaffold-only Cursor command/rule files and scrubbing related references from copied projects.
> 
> **Overview**
> Updates the `/new-project` command instructions so newly copied projects **delete scaffold-only Cursor artifacts** (e.g., `/new-project`, `/update`, `/bump-scaffold` command files and `scaffold-protection.mdc`) during cleanup.
> 
> Also tightens the post-copy checklist to **remove scaffold-only command references** from `.cursor/commands/help.md` and, if retained, the starter `README.md`, ensuring derived projects don’t advertise scaffold-maintainer workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bfff46189690457979c95bca5ddc6b4f3fef8fe. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->