### PR TITLE
feat(commands): let /new-project target personal or org GitHub repo

### DIFF
--- a/.cursor/commands/help.md
+++ b/.cursor/commands/help.md
@@ -11,37 +11,50 @@ Display this information in a friendly, clear way:
 ## 👋 Welcome! Here are the commands you can use:
 
 ### 🚀 `/setup`
+
 **Run this first!** Installs everything your project needs to work.
+
 - Installs the package manager (pnpm) if needed
 - Downloads all project dependencies
 - Creates configuration files
 - Takes about 1-2 minutes
 
 ### ▶️ `/start`
+
 **Launches your app** so you can see it in the browser.
+
 - Starts the development server
 - Open http://localhost:3000 to see your app
 - Changes you make will auto-refresh!
 
 ### 🆕 `/new-project`
+
 **Creates a fresh copy** of this template for a new project.
+
 - Prompts you to name your new project
 - Copies everything to a new folder
+- Lets you choose your personal GitHub account or an available organization
+- Creates a private GitHub repo and pushes the initial commit
 - Guides you to open it in Cursor
 
 ### 🔄 `/update`
+
 **Gets the latest scaffold updates** from the main repository.
+
 - Pulls new features and fixes
 - Warns you if you have uncommitted changes
 - Only works in the scaffold template (not derived projects)
 
 ### 📦 `/bump-scaffold`
+
 **Maintainer command** to roll the scaffold forward to the next monthly version.
+
 - Previews the rename before making changes
 - Can rename the GitHub repo and local folder
 - Can stop at the PR or wait and merge after CI
 
 ### ❓ `/help`
+
 **You're here!** Shows this list of commands.
 
 ---
@@ -49,26 +62,32 @@ Display this information in a friendly, clear way:
 ## 💡 Suggested Workflow
 
 **First time?** Do this:
+
 1. Type `/setup` and wait for it to finish
 2. Type `/start` to launch your app
 3. Open http://localhost:3000 in your browser
 
 **Starting a new project?**
+
 1. Type `/new-project`
 2. Give your project a name when asked
-3. Follow the instructions to open it in Cursor
-4. Run `/setup` in the new project
+3. Choose where to create the private GitHub repo
+4. Open the new project folder in Cursor
+5. Run `/setup` in the new project
 
 **Want the latest scaffold improvements?**
+
 1. Type `/update` to pull the latest changes
 2. Run `/setup` if dependencies changed
 
 **Maintaining the scaffold itself?**
+
 1. Type `/bump-scaffold`
 2. Review the dry-run preview carefully
 3. Confirm the PR, repo rename, and final local path rename
 
 **Need help anytime?**
+
 - Type `/help` to see this guide
 - Or just ask me anything in the chat!
 

--- a/.cursor/commands/new-project.md
+++ b/.cursor/commands/new-project.md
@@ -1,6 +1,6 @@
 # Create New Project
 
-Create a fresh copy of this scaffold as a new project, with its own private GitHub repo.
+Create a fresh copy of this scaffold as a new project, with its own private GitHub repo under either the user's GitHub account or an accessible organization.
 
 ## Instructions for AI
 
@@ -10,26 +10,28 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
 
 - `gh` CLI must be installed and authenticated (`gh auth status`)
 - If not authenticated, instruct the user to run `gh auth login` first
+- The authenticated GitHub account must have permission to create repositories in the selected destination account or organization
+- If expected organizations or teams do not appear, the user may need to refresh `gh` permissions with `gh auth refresh -s read:org`
 
 ## Steps
 
 1. **Ask for project name FIRST** - Display this prompt:
 
-   ---
-   
+   ***
+
    ## 🆕 Let's create your new project!
-   
+
    **What would you like to name your project?**
-   
+
    Some tips for a good name:
    - Use lowercase letters
    - Use dashes instead of spaces (e.g., `my-cool-app`)
    - Keep it short and memorable
    - Examples: `todo-app`, `my-portfolio`, `awesome-project`
-   
+
    **Type your project name below:**
-   
-   ---
+
+   ***
 
    **WAIT for the user to respond with a name before proceeding!**
 
@@ -38,16 +40,45 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
    - If name has uppercase, convert to lowercase and confirm
    - If name has special characters (except dashes), ask them to choose a different name
 
-3. **Ask where to create it** (optional):
+3. **Ask where to create it locally** (optional):
    - Default: parent directory of current project
    - Ask: "I'll create this in `{parent-directory}`. Is that okay, or would you like a different location?"
 
-4. **Copy the scaffold** - Run this command:
+4. **Ask where to create the GitHub repo**:
+   - First verify GitHub authentication:
+     ```bash
+     gh auth status
+     ```
+   - Get the authenticated user's login:
+     ```bash
+     gh api user --jq .login
+     ```
+   - Get organizations available to the authenticated user:
+     ```bash
+     gh api user/orgs --paginate --jq '.[].login'
+     ```
+   - Present the options clearly:
+     - Personal account: `<github-username>/<project-name>`
+     - Each available organization: `<org-login>/<project-name>`
+   - Ask: "Where should I create the private GitHub repo?"
+   - If no organizations are returned, explain that the project can be created under the personal account unless they authenticate with an account that has org access or refresh `gh` permissions with `gh auth refresh -s read:org`.
+   - Explain that the org list shows accessible organizations, but the final repo creation still depends on that org allowing the user to create repositories.
+   - If the user selects an organization, optionally ask whether a GitHub team should get access:
+     - List available teams with:
+       ```bash
+       gh api orgs/<org-login>/teams --paginate --jq '.[].slug'
+       ```
+     - If the team list command fails, continue without a team and mention that the org may require additional `gh` permissions such as `read:org`.
+     - If the user selects a team, remember the team slug for the repo creation command.
+
+5. **Copy the scaffold** - Run this command:
+
    ```bash
    cp -r "$(pwd)" "<destination>/<project-name>"
    ```
 
-5. **Clean up the new project**:
+6. **Clean up the new project**:
+
    ```bash
    cd "<destination>/<project-name>"
    rm -f .cursor/commands/new-project.md
@@ -59,49 +90,75 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
    rmdir scripts 2>/dev/null || true
    ```
 
-6. **Update copied scaffold metadata**:
+7. **Update copied scaffold metadata**:
    - Change the `"name"` field in `package.json` to the new project name
    - Remove the `"bump:scaffold"` script from `package.json`
    - Update `.cursor/commands/help.md` to remove `/new-project`, `/update`, and `/bump-scaffold` sections plus any scaffold-maintainer workflow text
    - If the copied project keeps the starter `README.md`, remove scaffold-only command references there as well
    - Make sure the new project does not advertise scaffold-only maintenance commands or include scaffold-protection prompts
 
-7. **Initialize fresh git repo**:
+8. **Initialize fresh git repo**:
+
    ```bash
    git init
    git add .
    git commit -m "Initial commit from scaffold"
    ```
 
-8. **Create a private GitHub repo and push**:
-   ```bash
-   gh repo create <project-name> --private --source . --push
-   ```
-   - This creates a private repo under the authenticated user's account, sets it as `origin`, and pushes
+9. **Create a private GitHub repo and push**:
+   - For a personal repo:
+     ```bash
+     gh repo create <github-username>/<project-name> --private --source . --push
+     ```
+   - For an organization repo:
+     ```bash
+     gh repo create <org-login>/<project-name> --private --source . --push
+     ```
+   - For an organization repo with team access:
+     ```bash
+     gh repo create <org-login>/<project-name> --private --team <team-slug> --source . --push
+     ```
+   - This creates a private repo, sets it as `origin`, and pushes the initial commit
    - If the repo name is already taken, append a suffix or ask the user for an alternative
+   - Do **not** run `vercel deploy` or create a Vercel project as part of `/new-project`
 
-9. **Display success message**:
+10. **Display success message**:
 
-   ---
-   
-   ## ✅ Your new project "{project-name}" is ready!
-   
-   **Project location:** `<full-path-to-new-project>`
-   **GitHub repo:** `https://github.com/<username>/<project-name>`
-   
-   ### 👉 Next Steps
-   
-   1. **Open your new project in Cursor:**
-      - Press `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows)
-      - Type "Open Folder" and select it
-      - Navigate to: `<full-path-to-new-project>`
-      - Click "Open"
-   
-   2. **Once you're in the new project, run `/setup`** to install dependencies
-   
-   3. **Then run `/start`** to launch your app!
-   
-   ---
+For a personal repo, use:
+
+```bash
+https://github.com/<github-username>/<project-name>
+```
+
+For an organization repo, use:
+
+```bash
+https://github.com/<org-login>/<project-name>
+```
+
+---
+
+## ✅ Your new project "{project-name}" is ready!
+
+**Project location:** `<full-path-to-new-project>`
+**GitHub repo:** `<github-repo-url>`
+
+### 👉 Next Steps
+
+1.  **Open your new project in Cursor:**
+    - Press `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows)
+    - Type "Open Folder" and select it
+    - Navigate to: `<full-path-to-new-project>`
+    - Click "Open"
+    - Important: keep working from this new folder, not the scaffold folder
+
+2.  **Once you're in the new project, run `/setup`** to install dependencies
+
+3.  **Then run `/start`** to launch your app!
+
+**No Vercel deployment was created.** This only created a local project and private GitHub repo.
+
+---
 
 ## Important Reminders
 
@@ -109,6 +166,9 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
 - Wait for user input at step 1 before running any commands
 - Make sure to use the exact name the user provides (after validation/conversion)
 - The GitHub repo is always created as **private** by default
+- Always ask whether the repo should be created under the personal GitHub account or an accessible organization
+- Make it very clear that the user must open the new project folder in Cursor after creation
+- Do not deploy to Vercel from this command
 
 ## Tone
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A clean, modern scaffold for full-stack web applications built with Next.js App 
 
 This project uses **Cursor commands** to make everything easy. Just type these commands in the Cursor chat:
 
-| Command | What it does |
-|---------|--------------|
-| `/setup` | Installs everything your project needs |
-| `/start` | Launches your app so you can see it in the browser |
-| `/new-project` | Creates a fresh copy of this template for a new project |
+| Command        | What it does                                                                 |
+| -------------- | ---------------------------------------------------------------------------- |
+| `/setup`       | Installs everything your project needs                                       |
+| `/start`       | Launches your app so you can see it in the browser                           |
+| `/new-project` | Creates a fresh copy of this template and pushes it to a private GitHub repo |
 
 ---
 
@@ -37,9 +37,12 @@ Want to create a new project using this template?
 
 1. Type `/new-project` in the chat
 2. Enter a name for your project (like `my-cool-app`)
-3. Follow the instructions to open your new project in Cursor
-4. Run `/setup` in the new project
-5. Run `/start` to launch it
+3. Choose whether the private GitHub repo should live under your personal account or an available organization
+4. Follow the instructions to open your new project folder in Cursor
+5. Run `/setup` in the new project
+6. Run `/start` to launch it
+
+`/new-project` creates a local folder and private GitHub repo only. It does not deploy to Vercel.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update `/new-project` instructions so the AI uses `gh` to list the authenticated user and their accessible orgs, then create the private repo as `user/repo` or `org/repo`, with optional `--team` for orgs.
- Document `gh auth refresh -s read:org` when orgs/teams are missing, permission caveats, and that no Vercel deploy runs from this command.
- Align `README.md` and `/help` with the new flow and stronger guidance to open the new folder in Cursor.

## Test plan
- [x] `gh auth status` on push host
- [x] Pre-push `tsc` and `next build` (ran via pre-push hook)
- [x] Manually read updated `.cursor/commands/new-project.md` for coherent step order and numbering


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to Cursor command instructions and README; main risk is users following the new `gh` flow and creating repos in the wrong account/org or with missing permissions.
> 
> **Overview**
> Updates the `/new-project` Cursor command instructions to let users create the new private GitHub repo under either their personal account or an accessible organization, including optional org team assignment via `gh` and guidance for missing org/team permissions (`gh auth refresh -s read:org`).
> 
> Aligns `/help` and `README.md` to reflect the new flow (choose repo destination, open the new folder in Cursor) and explicitly states that `/new-project` does **not** deploy to Vercel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7fc4d9319e9970dcc9ea6db30f61b28da0d8472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->