### PR TITLE
feat(internalsphere): add managed app project flow

### DIFF
--- a/.cursor/commands/help.md
+++ b/.cursor/commands/help.md
@@ -35,6 +35,7 @@ Display this information in a friendly, clear way:
 - Copies everything to a new folder
 - Lets you choose your personal GitHub account or an available organization
 - Creates a private GitHub repo and pushes the initial commit
+- **Auto-detects `internalsphere`**: if you pick that org, it uses the orchestrator flow (empty repo → bootstrap → app code via PR) so deploys "just work" — see `docs/internalsphere.md`
 - Guides you to open it in Cursor
 
 ### 🔄 `/update`

--- a/.cursor/commands/new-project.md
+++ b/.cursor/commands/new-project.md
@@ -159,6 +159,10 @@ detail and rationale: [`docs/internalsphere.md`](../../docs/internalsphere.md).
     ```bash
     gh repo create internalsphere/<project-name> --private
     ```
+    If the user selected a GitHub team in step 4, grant that team access when creating the repo:
+    ```bash
+    gh repo create internalsphere/<project-name> --private --team <team-slug>
+    ```
 2.  **Wait for the orchestrator to bootstrap it** (~1–2 min). It seeds `app-manifest.yml`,
     `.sops.yaml`, `secrets/`, `.github/workflows/managed-app.yml`, Cursor skills, `QUICKSTART.md`,
     and a baseline `vercel.json`, then auto-merges its bootstrap PR to `main`. Poll until `main` has

--- a/.cursor/commands/new-project.md
+++ b/.cursor/commands/new-project.md
@@ -166,10 +166,25 @@ detail and rationale: [`docs/internalsphere.md`](../../docs/internalsphere.md).
 2.  **Wait for the orchestrator to bootstrap it** (~1–2 min). It seeds `app-manifest.yml`,
     `.sops.yaml`, `secrets/`, `.github/workflows/managed-app.yml`, Cursor skills, `QUICKSTART.md`,
     and a baseline `vercel.json`, then auto-merges its bootstrap PR to `main`. Poll until `main` has
-    the baseline:
+    the baseline marker file:
+
     ```bash
-    gh api repos/internalsphere/<project-name>/commits --jq '.[].commit.message' | head
+    for attempt in {1..24}; do
+      if gh api repos/internalsphere/<project-name>/contents/app-manifest.yml >/dev/null 2>&1; then
+        echo "internalsphere bootstrap is ready"
+        break
+      fi
+
+      if [ "$attempt" -eq 24 ]; then
+        echo "Timed out waiting for internalsphere bootstrap; ask in #proj-internalsphere"
+        exit 1
+      fi
+
+      echo "Waiting for internalsphere bootstrap..."
+      sleep 10
+    done
     ```
+
 3.  **Clone the bootstrapped repo** into the destination and run one-time setup:
     ```bash
     git clone https://github.com/internalsphere/<project-name>.git "<destination>/<project-name>"

--- a/.cursor/commands/new-project.md
+++ b/.cursor/commands/new-project.md
@@ -6,6 +6,14 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
 
 **IMPORTANT: Always ask for the project name first before doing anything else!**
 
+> **internalsphere auto-detection:** This command supports two flows. If the destination GitHub org is
+> **`internalsphere`**, the repo is managed by the `internal-app-orchestrator` and you MUST use the
+> **internalsphere flow** (step 9b) instead of pushing the scaffold directly. Pushing a full scaffold
+> onto a fresh internalsphere repo collides with the orchestrator baseline (divergent history, a
+> policy-rejected `ci.yml`, a missing lockfile, and a 404 from a missing framework preset). For any
+> other destination, use the **standard flow** (step 9a). See [`docs/internalsphere.md`](../../docs/internalsphere.md)
+> for the why.
+
 ## Prerequisites
 
 - `gh` CLI must be installed and authenticated (`gh auth status`)
@@ -70,12 +78,20 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
        ```
      - If the team list command fails, continue without a team and mention that the org may require additional `gh` permissions such as `read:org`.
      - If the user selects a team, remember the team slug for the repo creation command.
+   - **Detect internalsphere:** if the chosen org is **`internalsphere`**, set the flow to the
+     **internalsphere flow (step 9b)** and tell the user this is a managed app that deploys via the
+     orchestrator. Otherwise use the **standard flow (step 9a)**.
 
 5. **Copy the scaffold** - Run this command:
 
    ```bash
    cp -r "$(pwd)" "<destination>/<project-name>"
    ```
+
+   > **internalsphere flow:** copy to a temporary source path instead — e.g.
+   > `cp -r "$(pwd)" "<destination>/<project-name>-src"` — because the final `<destination>/<project-name>`
+   > folder will be a clone of the orchestrator-managed repo (created in step 9b). Run the step 6/7
+   > cleanup + metadata edits inside that `-src` copy; you'll copy its app code into the clone in 9b.
 
 6. **Clean up the new project**:
 
@@ -90,6 +106,9 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
    rmdir scripts 2>/dev/null || true
    ```
 
+   > **Keep** `vercel.json`, `docs/internalsphere.md`, and `.cursor/rules/internalsphere.mdc` — these
+   > are real project files (not scaffold-maintenance files) and must carry over to the new project.
+
 7. **Update copied scaffold metadata**:
    - Change the `"name"` field in `package.json` to the new project name
    - Remove the `"bump:scaffold"` script from `package.json`
@@ -97,7 +116,8 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
    - If the copied project keeps the starter `README.md`, remove scaffold-only command references there as well
    - Make sure the new project does not advertise scaffold-only maintenance commands or include scaffold-protection prompts
 
-8. **Initialize fresh git repo**:
+8. **Initialize fresh git repo** (standard flow only — the internalsphere flow gets its git history by
+   cloning the managed repo in step 9b, so skip this step for internalsphere):
 
    ```bash
    git init
@@ -105,7 +125,8 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
    git commit -m "Initial commit from scaffold"
    ```
 
-9. **Create a private GitHub repo and push**:
+9a. **Standard flow — create a private GitHub repo and push** (use this for personal accounts and any
+   org that is **not** `internalsphere`):
    - For a personal repo:
      ```bash
      gh repo create <github-username>/<project-name> --private --source . --push
@@ -121,6 +142,53 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
    - This creates a private repo, sets it as `origin`, and pushes the initial commit
    - If the repo name is already taken, append a suffix or ask the user for an alternative
    - Do **not** run `vercel deploy` or create a Vercel project as part of `/new-project`
+
+9b. **internalsphere flow** (use this when the chosen org is **`internalsphere`**). The
+   `internal-app-orchestrator` owns Vercel, CI, branch protection, and the baseline files — so you
+   create an **empty** repo, let it bootstrap, and then add the scaffold's app code via a PR. Full
+   detail and rationale: [`docs/internalsphere.md`](../../docs/internalsphere.md).
+
+   1. **Create an empty private repo** (no `--source`, no `--push`):
+      ```bash
+      gh repo create internalsphere/<project-name> --private
+      ```
+   2. **Wait for the orchestrator to bootstrap it** (~1–2 min). It seeds `app-manifest.yml`,
+      `.sops.yaml`, `secrets/`, `.github/workflows/managed-app.yml`, Cursor skills, `QUICKSTART.md`,
+      and a baseline `vercel.json`, then auto-merges its bootstrap PR to `main`. Poll until `main` has
+      the baseline:
+      ```bash
+      gh api repos/internalsphere/<project-name>/commits --jq '.[].commit.message' | head
+      ```
+   3. **Clone the bootstrapped repo** into the destination and run one-time setup:
+      ```bash
+      git clone https://github.com/internalsphere/<project-name>.git "<destination>/<project-name>"
+      cd "<destination>/<project-name>"
+      sh scripts/setup-repo.sh
+      ```
+   4. **Add the scaffold app code on a branch.** Copy the cleaned app code from the `-src` copy you made
+      in step 5 into the clone — `src/`, `public/`, `prisma/`, and root config like `package.json`,
+      `tsconfig*.json`, `next.config.ts`, `eslint.config.mjs`, `postcss.config.mjs`,
+      `tailwind.config.ts`, `components.json`, `.cursor/rules/` (incl. `internalsphere.mdc`),
+      `.cursor/commands/`, and `docs/`. **Do NOT copy or overwrite orchestrator-managed files**: any
+      `.github/workflows/*`, `CODEOWNERS`, `.sops.yaml`, `secrets/`, git hooks, `scripts/`,
+      `QUICKSTART.md`. **Do NOT add a `.github/workflows/ci.yml`** (it fails the `ci-required` policy
+      check). Delete the `-src` copy when done.
+   5. **Merge `framework: nextjs` into the orchestrator's `vercel.json`** (don't overwrite it — keep
+      its `git.deploymentEnabled: false`). The result should be:
+      ```json
+      { "framework": "nextjs", "git": { "deploymentEnabled": false } }
+      ```
+   6. **Install to generate the lockfile, then commit and open a PR:**
+      ```bash
+      pnpm install
+      git checkout -b add-app-code
+      git add -A
+      git commit -m "Add app scaffold"
+      git push -u origin add-app-code
+      gh pr create --base main --fill
+      ```
+   7. **Merge when green.** The `internalsphere-ranger` bot posts the preview URL on the PR; merging to
+      `main` triggers the production deploy. Do **not** run `vercel deploy` yourself.
 
 10. **Display success message**:
 
@@ -156,7 +224,13 @@ https://github.com/<org-login>/<project-name>
 
 3.  **Then run `/start`** to launch your app!
 
-**No Vercel deployment was created.** This only created a local project and private GitHub repo.
+**Standard flow:** No Vercel deployment was created. This only created a local project and private
+GitHub repo.
+
+**internalsphere flow:** The orchestrator owns deploys — your app goes live automatically when the
+app-code PR merges to `main`. Find the project and its canonical URL under
+`https://vercel.com/anysphere-internal/<project-name>/deployments`. See
+[`docs/internalsphere.md`](../../docs/internalsphere.md) for the full workflow and the 404 checklist.
 
 ---
 
@@ -167,8 +241,9 @@ https://github.com/<org-login>/<project-name>
 - Make sure to use the exact name the user provides (after validation/conversion)
 - The GitHub repo is always created as **private** by default
 - Always ask whether the repo should be created under the personal GitHub account or an accessible organization
+- **If the chosen org is `internalsphere`, use the internalsphere flow (step 9b) — never push the scaffold onto a fresh internalsphere repo**
 - Make it very clear that the user must open the new project folder in Cursor after creation
-- Do not deploy to Vercel from this command
+- Do not run `vercel deploy` yourself in either flow (internalsphere deploys happen via the orchestrator on merge)
 
 ## Tone
 

--- a/.cursor/commands/new-project.md
+++ b/.cursor/commands/new-project.md
@@ -82,21 +82,26 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
      **internalsphere flow (step 9b)** and tell the user this is a managed app that deploys via the
      orchestrator. Otherwise use the **standard flow (step 9a)**.
 
-5. **Copy the scaffold** - Run this command:
+5. **Copy the scaffold** - Set a source path for the cleaned scaffold copy:
 
    ```bash
-   cp -r "$(pwd)" "<destination>/<project-name>"
+   # Standard flow
+   scaffold_source="<destination>/<project-name>"
+
+   # internalsphere flow
+   scaffold_source="<destination>/<project-name>-src"
+
+   cp -r "$(pwd)" "$scaffold_source"
    ```
 
-   > **internalsphere flow:** copy to a temporary source path instead — e.g.
-   > `cp -r "$(pwd)" "<destination>/<project-name>-src"` — because the final `<destination>/<project-name>`
-   > folder will be a clone of the orchestrator-managed repo (created in step 9b). Run the step 6/7
-   > cleanup + metadata edits inside that `-src` copy; you'll copy its app code into the clone in 9b.
+   Use the standard value unless the chosen GitHub org is `internalsphere`. For internalsphere, the
+   final `<destination>/<project-name>` folder will be a clone of the orchestrator-managed repo
+   (created in step 9b), so the cleaned scaffold source must live at `<project-name>-src`.
 
 6. **Clean up the new project**:
 
    ```bash
-   cd "<destination>/<project-name>"
+   cd "$scaffold_source"
    rm -f .cursor/commands/new-project.md
    rm -f .cursor/commands/update.md
    rm -f .cursor/commands/bump-scaffold.md
@@ -110,6 +115,7 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
    > are real project files (not scaffold-maintenance files) and must carry over to the new project.
 
 7. **Update copied scaffold metadata**:
+   - Make these edits inside `$scaffold_source`
    - Change the `"name"` field in `package.json` to the new project name
    - Remove the `"bump:scaffold"` script from `package.json`
    - Update `.cursor/commands/help.md` to remove `/new-project`, `/update`, and `/bump-scaffold` sections plus any scaffold-maintainer workflow text
@@ -126,71 +132,72 @@ Create a fresh copy of this scaffold as a new project, with its own private GitH
    ```
 
 9a. **Standard flow — create a private GitHub repo and push** (use this for personal accounts and any
-   org that is **not** `internalsphere`):
-   - For a personal repo:
-     ```bash
-     gh repo create <github-username>/<project-name> --private --source . --push
-     ```
-   - For an organization repo:
-     ```bash
-     gh repo create <org-login>/<project-name> --private --source . --push
-     ```
-   - For an organization repo with team access:
-     ```bash
-     gh repo create <org-login>/<project-name> --private --team <team-slug> --source . --push
-     ```
-   - This creates a private repo, sets it as `origin`, and pushes the initial commit
-   - If the repo name is already taken, append a suffix or ask the user for an alternative
-   - Do **not** run `vercel deploy` or create a Vercel project as part of `/new-project`
+org that is **not** `internalsphere`):
+
+- For a personal repo:
+  ```bash
+  gh repo create <github-username>/<project-name> --private --source . --push
+  ```
+- For an organization repo:
+  ```bash
+  gh repo create <org-login>/<project-name> --private --source . --push
+  ```
+- For an organization repo with team access:
+  ```bash
+  gh repo create <org-login>/<project-name> --private --team <team-slug> --source . --push
+  ```
+- This creates a private repo, sets it as `origin`, and pushes the initial commit
+- If the repo name is already taken, append a suffix or ask the user for an alternative
+- Do **not** run `vercel deploy` or create a Vercel project as part of `/new-project`
 
 9b. **internalsphere flow** (use this when the chosen org is **`internalsphere`**). The
-   `internal-app-orchestrator` owns Vercel, CI, branch protection, and the baseline files — so you
-   create an **empty** repo, let it bootstrap, and then add the scaffold's app code via a PR. Full
-   detail and rationale: [`docs/internalsphere.md`](../../docs/internalsphere.md).
+`internal-app-orchestrator` owns Vercel, CI, branch protection, and the baseline files — so you
+create an **empty** repo, let it bootstrap, and then add the scaffold's app code via a PR. Full
+detail and rationale: [`docs/internalsphere.md`](../../docs/internalsphere.md).
 
-   1. **Create an empty private repo** (no `--source`, no `--push`):
-      ```bash
-      gh repo create internalsphere/<project-name> --private
-      ```
-   2. **Wait for the orchestrator to bootstrap it** (~1–2 min). It seeds `app-manifest.yml`,
-      `.sops.yaml`, `secrets/`, `.github/workflows/managed-app.yml`, Cursor skills, `QUICKSTART.md`,
-      and a baseline `vercel.json`, then auto-merges its bootstrap PR to `main`. Poll until `main` has
-      the baseline:
-      ```bash
-      gh api repos/internalsphere/<project-name>/commits --jq '.[].commit.message' | head
-      ```
-   3. **Clone the bootstrapped repo** into the destination and run one-time setup:
-      ```bash
-      git clone https://github.com/internalsphere/<project-name>.git "<destination>/<project-name>"
-      cd "<destination>/<project-name>"
-      sh scripts/setup-repo.sh
-      ```
-   4. **Add the scaffold app code on a branch.** Copy the cleaned app code from the `-src` copy you made
-      in step 5 into the clone — `src/`, `public/`, `prisma/`, and root config like `package.json`,
-      `tsconfig*.json`, `next.config.ts`, `eslint.config.mjs`, `postcss.config.mjs`,
-      `tailwind.config.ts`, `components.json`, `.cursor/rules/` (incl. `internalsphere.mdc`),
-      `.cursor/commands/`, and `docs/`. **Do NOT copy or overwrite orchestrator-managed files**: any
-      `.github/workflows/*`, `CODEOWNERS`, `.sops.yaml`, `secrets/`, git hooks, `scripts/`,
-      `QUICKSTART.md`. **Do NOT add a `.github/workflows/ci.yml`** (it fails the `ci-required` policy
-      check). Delete the `-src` copy when done.
-   5. **Merge `framework: nextjs` into the orchestrator's `vercel.json`** (don't overwrite it — keep
-      its `git.deploymentEnabled: false`). The result should be:
-      ```json
-      { "framework": "nextjs", "git": { "deploymentEnabled": false } }
-      ```
-   6. **Install to generate the lockfile, then commit and open a PR:**
-      ```bash
-      pnpm install
-      git checkout -b add-app-code
-      git add -A
-      git commit -m "Add app scaffold"
-      git push -u origin add-app-code
-      gh pr create --base main --fill
-      ```
-   7. **Merge when green.** The `internalsphere-ranger` bot posts the preview URL on the PR; merging to
-      `main` triggers the production deploy. Do **not** run `vercel deploy` yourself.
+1.  **Create an empty private repo** (no `--source`, no `--push`):
+    ```bash
+    gh repo create internalsphere/<project-name> --private
+    ```
+2.  **Wait for the orchestrator to bootstrap it** (~1–2 min). It seeds `app-manifest.yml`,
+    `.sops.yaml`, `secrets/`, `.github/workflows/managed-app.yml`, Cursor skills, `QUICKSTART.md`,
+    and a baseline `vercel.json`, then auto-merges its bootstrap PR to `main`. Poll until `main` has
+    the baseline:
+    ```bash
+    gh api repos/internalsphere/<project-name>/commits --jq '.[].commit.message' | head
+    ```
+3.  **Clone the bootstrapped repo** into the destination and run one-time setup:
+    ```bash
+    git clone https://github.com/internalsphere/<project-name>.git "<destination>/<project-name>"
+    cd "<destination>/<project-name>"
+    sh scripts/setup-repo.sh
+    ```
+4.  **Add the scaffold app code on a branch.** Copy the cleaned app code from the `-src` copy you made
+    in step 5 into the clone — `src/`, `public/`, `prisma/`, and root config like `package.json`,
+    `tsconfig*.json`, `next.config.ts`, `eslint.config.mjs`, `postcss.config.mjs`,
+    `tailwind.config.ts`, `components.json`, `.cursor/rules/` (incl. `internalsphere.mdc`),
+    `.cursor/commands/`, and `docs/`. **Do NOT copy or overwrite orchestrator-managed files**: any
+    `.github/workflows/*`, `CODEOWNERS`, `.sops.yaml`, `secrets/`, git hooks, `scripts/`,
+    `QUICKSTART.md`. **Do NOT add a `.github/workflows/ci.yml`** (it fails the `ci-required` policy
+    check). Delete the `-src` copy when done.
+5.  **Merge `framework: nextjs` into the orchestrator's `vercel.json`** (don't overwrite it — keep
+    its `git.deploymentEnabled: false`). The result should be:
+    ```json
+    { "framework": "nextjs", "git": { "deploymentEnabled": false } }
+    ```
+6.  **Install to generate the lockfile, then commit and open a PR:**
+    ```bash
+    pnpm install
+    git checkout -b add-app-code
+    git add -A
+    git commit -m "Add app scaffold"
+    git push -u origin add-app-code
+    gh pr create --base main --fill
+    ```
+7.  **Merge when green.** The `internalsphere-ranger` bot posts the preview URL on the PR; merging to
+    `main` triggers the production deploy. Do **not** run `vercel deploy` yourself.
 
-10. **Display success message**:
+8.  **Display success message**:
 
 For a personal repo, use:
 

--- a/.cursor/rules/internalsphere.mdc
+++ b/.cursor/rules/internalsphere.mdc
@@ -1,0 +1,46 @@
+---
+description: internalsphere app conventions — deploy via the orchestrator, pin the Next.js framework preset, never edit managed files
+alwaysApply: true
+---
+
+# internalsphere Apps
+
+This project may live on **internalsphere** (GitHub org `internalsphere` + Vercel team
+`anysphere-internal`), managed by the `internal-app-orchestrator` (the "ranger"). If so, follow these
+rules so you don't fight the control plane. Full reference: [`docs/internalsphere.md`](../../docs/internalsphere.md)
+(local, dated copy) and the canonical Notion guide:
+https://www.notion.so/cursorai/internalsphere-348da74ef0458184af80e67adbcef6b7
+
+## How to tell it's an internalsphere app
+
+- The git remote is under `github.com/internalsphere/...`, **and/or**
+- The repo contains orchestrator-managed files: `app-manifest.yml`, `.sops.yaml`, `secrets/`,
+  `QUICKSTART.md`, `.github/workflows/managed-app.yml`.
+
+If none of these are present, it's a normal project and this rule doesn't apply.
+
+## Non-negotiables
+
+- **Pin the framework.** `vercel.json` must include `"framework": "nextjs"`. Missing it = Framework
+  Preset "Other" = production 404 on a green build. On internalsphere, the orchestrator's `vercel.json`
+  ships `{"git": {"deploymentEnabled": false}}` — **add** `"framework": "nextjs"` to it; do not remove
+  the `git` key (that re-enables Vercel's git integration and causes double deploys).
+- **Deploy = push.** Open a PR → preview deploy; merge to `main` → production. Never run
+  `vercel deploy` / `vercel env pull` / `vercel dev` (everyone has Viewer access only).
+- **Don't add your own CI.** No `.github/workflows/ci.yml` — CI and deploys run through orchestrator
+  reusable workflows. A custom workflow fails the `ci-required` policy check.
+- **Commit `pnpm-lock.yaml`.** CI installs with `--frozen-lockfile`.
+- **Never edit managed files** (overwritten on reconcile): managed workflows, `CODEOWNERS`,
+  `.sops.yaml`, git hooks, `scripts/setup-repo.sh`, `scripts/secrets*.py`, `scripts/app-manifest.py`,
+  distributed skill files, `secrets/inventory.yaml`, `QUICKSTART.md`. App-specific toggles live in
+  `app-manifest.yml`.
+- **Secrets/env vars** go through `python3 scripts/secrets.py` (SOPS-encrypted in `secrets/`), never
+  plaintext `.env` or `vercel env add`.
+- **Integrations** (Supabase / Upstash KV / Blob) are declared in `app-manifest.yml` under
+  `integrations:`; the orchestrator provisions them.
+
+## Creating a new internalsphere app
+
+Do **not** push the scaffold on top of a fresh repo. Create an **empty** repo under `internalsphere`,
+let the orchestrator bootstrap it (auto-merged baseline PR), then add app code via a normal PR. The
+`/new-project` command handles this automatically when the chosen org is `internalsphere`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,24 @@ Want to create a new project using this template?
 5. Run `/setup` in the new project
 6. Run `/start` to launch it
 
-`/new-project` creates a local folder and private GitHub repo only. It does not deploy to Vercel.
+For a personal or standard org repo, `/new-project` creates a local folder and private GitHub repo
+only — it does not deploy to Vercel.
+
+---
+
+## 🏢 internalsphere Apps
+
+If you create the project under the **`internalsphere`** GitHub org, it's a managed app deployed by the
+`internal-app-orchestrator`. `/new-project` detects this automatically and uses the orchestrator flow
+(create an empty repo → let it bootstrap → add app code via a PR) instead of pushing the scaffold
+directly — so you don't collide with the baseline or hit the framework-preset 404.
+
+- **Local reference (dated):** [`docs/internalsphere.md`](docs/internalsphere.md)
+- **Canonical guide (Notion):** https://www.notion.so/cursorai/internalsphere-348da74ef0458184af80e67adbcef6b7
+- Key gotchas are also encoded in the always-on rule `.cursor/rules/internalsphere.mdc`.
+
+This scaffold ships a `vercel.json` with `"framework": "nextjs"` so the Next.js preset is correct by
+default — the one thing that 404'd our first internalsphere deploy.
 
 ---
 

--- a/docs/internalsphere.md
+++ b/docs/internalsphere.md
@@ -1,0 +1,276 @@
+# internalsphere — Internal Apps Platform Guide
+
+> **Local copy captured:** 2026-06-30
+> **Canonical source (Notion):** https://www.notion.so/cursorai/internalsphere-348da74ef0458184af80e67adbcef6b7
+>
+> This is a point-in-time, offline copy for quick reference. **The Notion doc is the source of
+> truth** — if anything here looks stale, check Notion and update this file (and bump the date above).
+> On a live internalsphere repo, the orchestrator also ships `@internalsphere-setup` and
+> `QUICKSTART.md`, which stay in sync automatically.
+
+This guide is for anyone building internal apps at Cursor. It explains what internalsphere is, how to
+get set up, how to ship changes, and answers the questions people ask most often.
+
+---
+
+## What is internalsphere?
+
+**internalsphere** is the home for internal apps — little tools and dashboards that only people
+inside Cursor use. It's a GitHub organization ([github.com/internalsphere](https://github.com/internalsphere))
+plus a Vercel team (`anysphere-internal`) wired together so anyone can ship a real web app without
+having to understand hosting, secrets management, CI/CD, or security on day one.
+
+This is made possible by an orchestrator repo called `internal-app-orchestrator` (also called the
+**"ranger"** or **"control plane"**). It watches every internal-app repo and keeps everything set up
+correctly:
+
+- Creates and links the Vercel project for you.
+- Configures environment variables and secrets.
+- Sets up branch protection, CODEOWNERS, and security checks.
+- Deploys to **preview** on every PR and to **production** on every merge to the default branch
+  (`main`).
+- If any of the above drifts out of policy, it opens a PR to fix it automatically (auto-admin-merged
+  by the `internalsphere-ranger` bot).
+
+> **Mental model:** you write app code; the orchestrator handles everything else around it. You
+> almost **never** edit Vercel settings, GitHub settings, or workflow files directly.
+
+---
+
+## First-time setup (once per laptop)
+
+### 1. Join the GitHub org
+
+Search Okta for `Github - Internalsphere`. If you don't have access, ping `#proj-internalsphere`.
+
+### 2. Authorize your SSH key for internalsphere (most common setup error)
+
+`anysphere` and `internalsphere` are separate GitHub orgs, so SSH access must be SSO-authorized for
+each one. If you already use GitHub for `anysphere`, you almost certainly have a working key:
+
+1. Go to https://github.com/settings/keys
+2. Find your existing SSH key.
+3. Click **Configure SSO** → enable it for `internalsphere`.
+4. Test: `ssh -T git@github.com` → should say "Hi \<your-username\>!"
+
+> If `git clone` fails with "Permission denied (publickey)" or "Repository not found" on an
+> internalsphere repo, **99% of the time this step is the fix.**
+
+### 3. Install the basics
+
+```bash
+brew install git gh sops age python pnpm node
+gh auth login
+```
+
+- `git`, `gh` — version control + GitHub CLI
+- `sops` + `age` — encrypt secrets before they're committed to git
+- `python`, `pnpm`, `node` — for running repo scripts
+
+### 4. Vercel access (optional)
+
+Search Okta for `Vercel-Internal`. You'll have **Viewer** access — enough to view deploys, but **not**
+enough to view env var names/values or run `vercel env pull` / `vercel dev`. Use the PR preview flow
+instead.
+
+---
+
+## Creating a new app
+
+1. Create an **empty** repo under the **`internalsphere`** org
+   ([new repo](https://github.com/organizations/internalsphere/repositories/new)).
+   - Pick a clear name like `my-cool-dashboard`.
+   - Make it **Private** or **Internal**.
+   - Use `main` as the branch name.
+2. **Wait a minute or two.** The orchestrator picks up the new repo and bootstraps it (Vercel project,
+   branch protection, CODEOWNERS, security rulesets, `app-manifest.yml`, `.sops.yaml`, `secrets/`, CI
+   workflows, Cursor skills), then opens and auto-merges a bootstrap PR.
+3. **Now** start building: clone, run `sh scripts/setup-repo.sh` (one-time), and push your app code
+   via a PR.
+
+> **TL;DR:** Create an empty private repo in `internalsphere` with a `main` branch, wait ~1 minute for
+> the bootstrap PR to merge, then start pushing code. You **do not** scaffold platform files by hand —
+> the bootstrap PR does it for you.
+
+> ⚠️ **Do not push a full app scaffold on top of a fresh repo before the orchestrator bootstraps it.**
+> The baseline commit on `main` will diverge from your push, and a hand-written `.github/workflows/ci.yml`
+> will fail the `ci-required` policy check. Let the bootstrap land first, then add app code via a PR.
+
+---
+
+## Making changes to an existing app
+
+1. Clone (once): `git clone git@github.com:internalsphere/<repo-name>.git && cd <repo-name>`
+2. One-time per repo: `sh scripts/setup-repo.sh` (installs git hooks + local deps)
+3. Branch: `git checkout -b my-change`
+4. Edit, commit, push.
+5. Open a PR. You'll see:
+   - A **Vercel preview URL** (posted by the `internalsphere-ranger` bot).
+   - **Bugbot** and **Security Bugbot** review comments.
+   - CI checks (lint, secret scan, etc.).
+6. Merge when green → the orchestrator deploys to production automatically.
+
+> 🤖 If two preview-URL comments show up, use the one from the **`internalsphere-ranger`** bot — ignore
+> the `Vercel` bot's.
+
+---
+
+## Deploying your changes
+
+**You do not run any deploy commands. Pushing to GitHub *is* deploying.**
+
+1. **Open or push to a PR** → Vercel publishes a **preview deploy** at a unique URL (same URL updates
+   on every push to the PR).
+2. **Merge the PR into `main`** → Vercel publishes a **production deploy**.
+
+> 🚫 You can't `vercel deploy` from your laptop, and you shouldn't try. Everyone on `anysphere-internal`
+> has **Viewer** access (can't deploy). Deploys must go through the managed GitHub Actions workflow so
+> `secrets/` get decrypted, env vars get synced, and the audit inventory gets written.
+
+---
+
+## Environment variables and secrets
+
+All env vars — sensitive or not — live in the repo **encrypted** with SOPS + age, under
+`secrets/shared/`, `secrets/preview/`, or `secrets/production/`. CI decrypts them at build time and
+ships them to Vercel as sensitive env vars.
+
+```bash
+python3 scripts/secrets.py list   --scope local
+python3 scripts/secrets.py list   --scope remote --env production
+python3 scripts/secrets.py add    --scope production --key MY_SECRET_NAME
+python3 scripts/secrets.py update --scope production --key MY_SECRET_NAME
+python3 scripts/secrets.py delete --scope production --key MY_SECRET_NAME
+```
+
+Scopes: `shared` (all envs), `preview`, `production`. Key names must match `^[A-Z][A-Z0-9_]*$`. Commit
+the resulting `secrets/<scope>/<KEY>.sops.json`, open a PR, merge — CI syncs to Vercel.
+
+> 🚫 **Never** paste a raw secret into `.env`, code, tests, commit messages, or `vercel env add`. The
+> `secrets-guard.py` pre-commit hook, CI scanning, and Security Bugbot all catch it.
+
+---
+
+## Integrations (databases, caches, storage)
+
+Declare integrations in `app-manifest.yml` under `integrations:`. Each entry is keyed by an **alias you
+choose** and has a single required field, `type`:
+
+```yaml
+version: 1
+integrations:
+  db:
+    type: supabase
+  cache:
+    type: upstash-kv
+  assets:
+    type: blob
+```
+
+`version: 1` is the **manifest schema version**, not a per-change revision — leave it at `1`.
+
+Your alias becomes the env var prefix Vercel generates:
+
+| Alias | Type | Example env vars |
+| --- | --- | --- |
+| `db` | `supabase` | `DB_POSTGRES_URL`, `DB_SUPABASE_URL`, `DB_SUPABASE_SERVICE_ROLE_KEY`, … |
+| `cache` | `upstash-kv` | `CACHE_KV_REST_API_URL`, `CACHE_KV_REST_API_TOKEN` |
+| `assets` | `blob` | `ASSETS_READ_WRITE_TOKEN` |
+
+Open a PR and merge. The orchestrator provisions the backing resource and injects credentials into
+Vercel. Per-integration Cursor skills ship in each repo: `supabase-database`, `upstash-redis`,
+`vercel-blob-store`.
+
+---
+
+## Sharing with external viewers
+
+To share a deployment with someone outside Cursor, add a time-bound grant to `external-viewers.yml`
+at the repo root:
+
+```yaml
+version: 1
+viewers:
+  - target: my-app-preview.vercel.app
+    email: partner@example.com
+    expires_at: "2026-06-19T00:00:00Z"
+    requested_by: "@you"
+    reason: "Customer pitch review"
+```
+
+Open a PR — `@internalsphere/security` is tagged automatically. After merge, the orchestrator grants
+access in Vercel and revokes it at `expires_at` or when the entry is removed. Don't make a project
+public to share it.
+
+---
+
+## Why is my deployed app showing a 404?
+
+The deploy went green but the page says "Not Found". Canonical checklist:
+https://vercel.com/kb/guide/why-is-my-deployed-project-giving-404
+
+Most common causes:
+
+1. **Wrong URL.** A project's default hostname isn't always predictable. Confirm the canonical URL from
+   the project's Deployments tab at `https://vercel.com/anysphere-internal/<PROJECT>/deployments`.
+2. **Wrong framework preset.** For Next.js, Vercel must use the Next.js adapter. If the dashboard shows
+   **Framework Preset = Other**, pin it from the repo with `vercel.json`:
+   ```json
+   { "framework": "nextjs" }
+   ```
+   On internalsphere, the orchestrator's `vercel.json` ships `{"git": {"deploymentEnabled": false}}` —
+   **add** `"framework": "nextjs"` to it; don't remove the `git` key (that would re-enable Vercel's git
+   integration and cause double deploys). Do **not** point `outputDirectory` at `.next` for a
+   server-rendered app.
+   > **This was the exact bug that 404'd our first internalsphere app.** The scaffold now ships a
+   > `vercel.json` with `framework: nextjs` by default so it doesn't recur.
+3. **Wrong Output Directory.** Use `"dist"`/`"public"` only when your framework really emits static
+   files there. For Next.js, prefer the framework preset and omit `outputDirectory`.
+4. **Wrong Root Directory** (monorepos). If build logs show `next build` at the repo root but your app
+   lives in a subfolder, set `vercel.root_directory` in `app-manifest.yml` (not a `vercel.json` knob).
+5. **SPA missing a rewrite.** Vite/CRA apps need a catch-all:
+   ```json
+   { "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }] }
+   ```
+
+Still stuck? Check the dashboard's **Build Logs** and **Runtime Logs**, or ask in
+`#proj-internalsphere`.
+
+---
+
+## FAQ highlights
+
+- **Who can access my app?** SSO-protected to Cursor employees by default. Share externally via
+  `external-viewers.yml`.
+- **How do deploys happen?** Open a PR (preview) and merge into `main` (production). No local deploy
+  commands.
+- **Find my deployments:** https://vercel.com/anysphere-internal → click the project → **Deployments**
+  (top Production entry has the canonical URL).
+- **Can I run `vercel env pull` / `vercel dev` / `vercel deploy`?** No — Viewer access only. Iterate via
+  PR previews.
+- **Why can't I force-merge into `main`?** It's protected (PR + passing CI + CODEOWNER approval for
+  managed files). Only the `internalsphere-ranger` bot admin-merges its own baseline PRs.
+- **Roll back a bad deploy:** Revert the PR on GitHub and merge the revert.
+
+---
+
+## Guardrails (don't fight the orchestrator)
+
+- **Never edit policy-managed files** — they're overwritten on every reconciliation:
+  managed workflows (`.github/workflows/managed-app.yml` etc.), `CODEOWNERS`, `.sops.yaml`, git hooks,
+  `scripts/setup-repo.sh`, `scripts/install-secrets-tooling.sh`, `scripts/app-manifest.py`,
+  `scripts/secrets-guard.py`, `scripts/secrets.py`, distributed skill files, `secrets/inventory.yaml`,
+  and `QUICKSTART.md`. App-specific toggles go in `app-manifest.yml`.
+- **Don't add your own CI** (`.github/workflows/ci.yml`) — CI/deploy run through orchestrator reusable
+  workflows; a custom one fails the `ci-required` policy check.
+- **Commit `pnpm-lock.yaml`** — CI installs with `--frozen-lockfile`.
+- **Don't bypass hooks** with `--no-verify` — CI catches the same issues.
+
+---
+
+## Where to get help
+
+- **Slack:** `#proj-internalsphere`
+- **Full guide (source of truth):** https://www.notion.so/cursorai/internalsphere-348da74ef0458184af80e67adbcef6b7
+- **Orchestrator repo:** https://github.com/internalsphere/internal-app-orchestrator
+- **On a live repo:** `@internalsphere-setup` (Cursor skill) and `QUICKSTART.md`

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- Add a dated local internalsphere guide with the Notion source link and deploy/404 troubleshooting notes
- Teach `/new-project` to auto-detect the `internalsphere` org and use the orchestrator-managed repo flow instead of pushing the scaffold directly
- Add an internalsphere rule and pin Vercel to the Next.js framework preset by default

## Test plan
- Validated `vercel.json` parses as JSON
- Reviewed the generated git diff for the new command flow and documentation


Made with [Cursor](https://cursor.com)